### PR TITLE
fix: upgrade Angular compiler security patch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1388,9 +1388,9 @@
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "6.1.10",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-6.1.10.tgz",
-      "integrity": "sha512-FPIb2j3zfoBwb6vo/u0gQeu70h8InGlSisBr3xMACs/35/pwB6kbQR+JQiUr0D7k6QApg7AuMkvq8aFNelg0aw==",
+      "version": "20.3.27",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-20.3.27.tgz",
+      "integrity": "sha512-in3THZ678GAYuOR9RZV18+zZz0KGhlGikyUEfLeALLjGf9ZaR3n+t19BmYx6G2VkF/Xqadne1omQ2vbl6PRASA==",
       "dependencies": {
         "tslib": "^1.9.0"
       }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@angular/animations": "^6.1.0",
     "@angular/common": "^6.1.0",
-    "@angular/compiler": "^6.1.0",
+    "@angular/compiler": "~20.3.27",
     "@angular/core": "^20.3.27",
     "@angular/forms": "^6.1.0",
     "@angular/http": "^6.1.0",


### PR DESCRIPTION
Aligns the direct @angular/compiler dependency and root lockfile instance with patched Angular 20.3.27. Full CI/build compatibility must pass before further migration work.